### PR TITLE
Add deploy-to-ecs github workflow

### DIFF
--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -49,9 +49,76 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+  deploy-to-ecs:
+    name: Deploy to ECS
+    runs-on: ubuntu-latest
+    needs: build-and-push-docker
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      AWS_REGION: eu-central-1
+      CLUSTER_NAME: unlimited-excellence-cluster
+      SERVICE_NAME: horse-project-service
+      TASK_DEF_NAME: horse-project-task
+      CONTAINER_NAME: horse-project
+      IMAGE_URI: ghcr.io/unlimited-excellence/horse-dao:main
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/GitHubActionsDeployRole
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Validate image exists in GHCR
+        run: |
+          echo "🔍 Checking if image $IMAGE_URI exists..."
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            https://ghcr.io/v2/unlimited-excellence/horse-dao/manifests/main)
+
+          if [ "$STATUS" -ne 200 ]; then
+            echo "❌ Image not found in GHCR (HTTP $STATUS) — aborting deploy."
+            exit 1
+          fi
+
+          echo "✅ Image exists in GHCR."
+
+      - name: Download current ECS task definition
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition ${{ env.TASK_DEF_NAME }} \
+            --query taskDefinition > task-definition.json
+
+      - name: Update container image in task definition
+        run: |
+          cat task-definition.json | \
+            jq '.containerDefinitions[0].image = "${{ env.IMAGE_URI }}"' \
+            > new-task-def.json
+
+      - name: Register new task definition revision
+        id: register-task-def
+        run: |
+          TASK_DEF_ARN=$(aws ecs register-task-definition \
+            --cli-input-json file://new-task-def.json \
+            --query 'taskDefinition.taskDefinitionArn' \
+            --output text)
+          echo "TASK_DEF_ARN=$TASK_DEF_ARN" >> $GITHUB_ENV
+
+      - name: Update ECS service with new task definition
+        run: |
+          aws ecs update-service \
+            --cluster ${{ env.CLUSTER_NAME }} \
+            --service ${{ env.SERVICE_NAME }} \
+            --task-definition ${{ env.TASK_DEF_ARN }}
 
   create-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a new deploy-to-ecs job to the existing GitHub Actions workflow, enabling automatic deployment of the latest Docker image to AWS ECS after each push to the main branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an automated deployment step that updates the live application environment immediately following successful builds.
  
- **Chores**
	- Enhanced deployment configuration with minor refinements for improved workflow clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->